### PR TITLE
fix: replace actions/cache v4 with v5 for Node.js 20 deprecation

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -148,6 +148,20 @@ runs:
         ulimit: ${{ inputs.ulimit }}
         build-args: ${{ inputs.build-args }}
 
+    - name: Get current date
+      if: ${{ inputs.run_trivy == 'true' }}
+      id: trivy-cache-date
+      shell: bash
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Restore Trivy DB from cache
+      if: ${{ inputs.run_trivy == 'true' }}
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ${{ github.workspace }}/.cache/trivy
+        key: cache-trivy-${{ steps.trivy-cache-date.outputs.date }}
+        restore-keys: cache-trivy-
+
     - name: Run Trivy vulnerability scanner
       if: ${{ inputs.run_trivy == 'true' }}
       id: trivy
@@ -161,6 +175,7 @@ runs:
         severity: "CRITICAL,HIGH"
         trivyignores: ./.trivyignore
         version: "v0.69.2"
+        cache: "false"
       env:
         TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
         TRIVY_DISABLE_VEX_NOTICE: true


### PR DESCRIPTION
## Summary
- Replace trivy-action's internal `actions/cache@v4.2.4` (Node.js 20) with explicit `actions/cache@v5.0.4`
- Disable trivy-action's built-in caching and manage Trivy DB cache externally
- Eliminates the Node.js 20 deprecation warning without waiting for upstream trivy-action update

## Test plan
- [ ] Verify Docker build workflow runs without Node.js 20 deprecation warning
- [ ] Verify Trivy DB cache is restored correctly on subsequent runs