### PR TITLE
ci: add CI to github-action-image-build-and-push (actionlint + smoke)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,64 @@
+name: CI
+
+# This repo had no CI at all. That mattered more here than usual: action.yaml is
+# the whole product, it is consumed by NethermindEth/github-workflows in both
+# docker-build-push-dockerhub.yaml and docker-build-push-jfrog.yaml, and those
+# are used by every repo that builds an image. So an unverified bump here can
+# break image build and push across the org with no signal anywhere.
+#
+# Dependabot also could not get anything merged, because a PR with zero checks
+# is indistinguishable from a PR whose checks have not run.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Lint action and workflow definitions
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+
+  smoke:
+    # Runs the action end to end with push-to-registry disabled, so it needs no
+    # registry credentials. That still exercises setup-buildx-action,
+    # metadata-action, build-push-action, actions/cache and trivy-action -- six
+    # of the eight actions pinned in action.yaml. Only attest-build-provenance
+    # is skipped, since it only runs when pushing.
+    name: smoke (run_trivy=${{ matrix.run_trivy }})
+    runs-on: ubuntu-latest
+    strategy:
+      # Both legs should report; one failing must not hide the other's result.
+      fail-fast: false
+      matrix:
+        run_trivy: ["true", "false"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # action.yaml's "Setup environment" step runs `git describe --tags`,
+          # which fails on the default shallow clone with no tags.
+          fetch-depth: 0
+
+      - name: Build a throwaway image through the action, without pushing
+        uses: ./
+        with:
+          push-to-registry: "false"
+          registry: "dockerhub"
+          image_name: "nethermindeth/ci-smoke-test"
+          image_tags: "smoke"
+          # Single platform keeps the smoke test fast; multi-arch adds minutes
+          # and exercises nothing extra here.
+          platforms: "linux/amd64"
+          context: "test/smoke"
+          dockerfile_path: "test/smoke/Dockerfile"
+          run_trivy: ${{ matrix.run_trivy }}

--- a/test/smoke/Dockerfile
+++ b/test/smoke/Dockerfile
@@ -1,0 +1,8 @@
+# Minimal image for the CI smoke test.
+#
+# FROM scratch on purpose: it contains no OS packages, so the Trivy step in the
+# action has a deterministic, permanently-clean target. A distro base image
+# would let an unrelated CVE published upstream turn this job red and tell us
+# nothing about the action itself.
+FROM scratch
+COPY hello.txt /hello.txt

--- a/test/smoke/hello.txt
+++ b/test/smoke/hello.txt
@@ -1,0 +1,1 @@
+CI smoke fixture. Built by .github/workflows/ci.yaml with push disabled.


### PR DESCRIPTION
hey team, can I get a review on this?

this repo had literally no CI, `.github/` was just `dependabot.yml`. that matters more here than usual since `action.yaml` IS the product, it's consumed by NethermindEth/github-workflows (`docker-build-push-dockerhub.yaml` and `docker-build-push-jfrog.yaml`), which every image-building repo in the org uses. an unverified bump here breaks build/push everywhere with no signal at all.

it also meant dependabot could never merge anything, PR #28 has been sitting there because a PR with 0 checks and a PR whose checks haven't run yet look the same. it bumps 8 pinned SHAs, including actions/cache v5.0.5 -> v6.1.0 (changelog: "update packages, migrate to ESM", real breaking major) and trivy-action 0.35.0 -> 0.36.0. once this merges #28 finally has something to pass.

what it does:
- `actionlint` job, lints the action + workflow yaml
- `smoke` job, runs the action end to end with `push-to-registry: false`, so no registry creds needed (action has no login step, that's on consumers). still exercises setup-buildx-action, metadata-action, build-push-action, actions/cache and trivy-action, 6 of the 8 pinned actions. only attest-build-provenance is skipped since it only runs on push
- matrix `run_trivy: ["true", "false"]`, `fail-fast: false`, so a fail in one leg doesn't hide the other
- `fetch-depth: 0` on checkout, action.yaml's "Setup environment" step runs `git describe --tags`, fails on a shallow clone with no tags
- smoke fixture is `FROM scratch` on purpose, no OS packages, so trivy stays permanently clean. a distro base image would let some random upstream CVE turn the job red telling us nothing about the action itself
- single platform (linux/amd64), multi-arch wouldn't exercise anything extra here

security:
- `pull_request`, not `pull_request_target`, fork PRs get a read-only token, no secrets access
- `permissions: contents: read`
- no untrusted input interpolated anywhere, the only `${{ }}` expression is `matrix.run_trivy`, a static matrix value
- both third-party actions pinned by commit SHA with version comment, matches action.yaml's existing convention so dependabot keeps them updated

btw this workflow verifies itself, it triggers on `pull_request` so this PR's own run is the proof it works.

Thoughts?
